### PR TITLE
Fix log messages that give the location of the generated certificates

### DIFF
--- a/run.py
+++ b/run.py
@@ -67,19 +67,18 @@ print("Done.")
 print("Fetch the certs and logs via cf files ...")
 print("You can get them with these commands: ")
 
-for entry in settings['domains']:
-    for host in entry['hosts']:
-        msg = ""
-        if entry['hosts'] is not None and host != '.':
-            msg = "cf files letsencrypt app/conf/live/" + host + "." + entry['domain']
-        else:
-            msg = "cf files letsencrypt app/conf/live/" + entry['domain']
-        print(msg + "/cert.pem")
-        print(msg + "/chain.pem")
-        print(msg + "/fullchain.pem")
-        print(msg + "/privkey.pem")
-        print()
+host = settings['domains'][0]['hosts'][0]
+domain = settings['domains'][0]['domain']
+path = host + "." + domain
 
+if host == '.':
+    path = domain
+
+print("cf files letsencrypt app/conf/live/" + path + "/cert.pem")
+print("cf files letsencrypt app/conf/live/" + path + "/chain.pem")
+print("cf files letsencrypt app/conf/live/" + path + "/fullchain.pem")
+print("cf files letsencrypt app/conf/live/" + path + "/privkey.pem")
+print()
 print("REMEMBER TO STOP THE SERVER WITH cf stop letsencrypt")
 
 # Sleep for a week


### PR DESCRIPTION
Let's Encrypt generates 1 certificate for all the requested hosts/domains.  This certificate has the primary name of the first listed host/domain.  Additional hosts/domains are added as Subject Alternative Names to the certificate.  LE uses this primary name as the name for the folder where the certificates are saved.
This fixes #3
